### PR TITLE
Deprecate the image set as it is not being used anymore

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -9,5 +9,5 @@
         "email": "origami.support@ft.com",
         "slack": "financialtimes/origami-support"
     },
-    "supportStatus": "active"
+    "supportStatus": "deprecated"
 }


### PR DESCRIPTION
Closes https://github.com/Financial-Times/origami-brand-images/issues/14

We've done a search of the Origami Image Service logs and found [no uses of this image-set for the last month](https://financialtimes.splunkcloud.com/en-GB/app/search/search?sid=1608050009.3068087).